### PR TITLE
Incorporated @danslo HHVM totals fixes for PHP7

### DIFF
--- a/app/code/local/Inchoo/PHP7/etc/config.xml
+++ b/app/code/local/Inchoo/PHP7/etc/config.xml
@@ -7,6 +7,19 @@
     </modules>
 
     <global>
+		<sales>
+            <quote>
+                <totals>
+                    <msrp>
+                        <before>grand_total</before>
+                    </msrp>
+                    <shipping>
+                        <after>subtotal,freeshipping,tax_subtotal,msrp</after>
+                    </shipping>
+                </totals>
+            </quote>
+        </sales>
+	
         <models>
             <inchoo_php7>
                 <class>Inchoo_PHP7_Model</class>

--- a/app/etc/modules/Inchoo_PHP7.xml
+++ b/app/etc/modules/Inchoo_PHP7.xml
@@ -7,6 +7,7 @@
             <depends>
                 <Mage_Core/>
                 <Mage_ImportExport/>
+				<Mage_Sales/>
             </depends>
         </Inchoo_PHP7>
     </modules>


### PR DESCRIPTION
PHP 7.x breaks the totals calculation in Magento 1.9.x (I believe also 1.8.x), so discounts are no longer applied.  This issue was raised a while ago against HHVM (https://github.com/facebook/hhvm/issues/2416) and subsequently patched.  The patch created by @danslo is incorporated here.

Technically this is not a PHP 7 incompatibility, but it is something that will manifest when trying to use PHP 7 with Magento 1.x, so thought it helpful to include here.