### PR TITLE
The Model Inchoo_PHP7_Model_Import_Uploader was not used.

### DIFF
--- a/app/code/local/Inchoo/PHP7/Model/Import/Entity/Product.php
+++ b/app/code/local/Inchoo/PHP7/Model/Import/Entity/Product.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Created on: 12.08.16.
+ * @author Oliver Ernst <ernst.o@idowapro.de>
+ */
+class Inchoo_PHP7_Model_Import_Entity_Product extends Mage_ImportExport_Model_Import_Entity_Product
+{
+
+    /**
+     * Returns an object for upload a media files
+     */
+    protected function _getUploader()
+    {
+        if (is_null($this->_fileUploader)) {
+            $this->_fileUploader = Mage::getModel("importexport/import_uploader", null);
+
+            $this->_fileUploader->init();
+
+            $tmpDir     = Mage::getConfig()->getOptions()->getMediaDir() . '/import';
+            $destDir    = Mage::getConfig()->getOptions()->getMediaDir() . '/catalog/product';
+            if (!is_writable($destDir)) {
+                @mkdir($destDir, 0777, true);
+            }
+            if (!$this->_fileUploader->setTmpDir($tmpDir)) {
+                Mage::throwException("File directory '{$tmpDir}' is not readable.");
+            }
+            if (!$this->_fileUploader->setDestDir($destDir)) {
+                Mage::throwException("File directory '{$destDir}' is not writable.");
+            }
+        }
+        return $this->_fileUploader;
+    }
+
+}

--- a/app/code/local/Inchoo/PHP7/etc/config.xml
+++ b/app/code/local/Inchoo/PHP7/etc/config.xml
@@ -35,6 +35,7 @@
             <importexport>
                 <rewrite>
                     <import_uploader>Inchoo_PHP7_Model_Import_Uploader</import_uploader>
+                    <import_entity_product>Inchoo_PHP7_Model_Import_Entity_Product</import_entity_product>
                     <export_entity_product_type_configurable>Inchoo_PHP7_Model_Export_Entity_Product_Type_Configurable</export_entity_product_type_configurable>
                     <export_entity_product_type_grouped>Inchoo_PHP7_Model_Export_Entity_Product_Type_Grouped</export_entity_product_type_grouped>
                     <export_entity_product_type_simple>Inchoo_PHP7_Model_Export_Entity_Product_Type_Simple</export_entity_product_type_simple>


### PR DESCRIPTION
The `Import_Uploader` model was not used because the Instance of the class was not created with the `Mage::getModel` factory. Therefore the model rewrite did not work. 

Here is the part of the `config.xml` which is responsible for the model rewrite:
```
<config>
    <global>
        <models>
            <importexport>
                <rewrite>
                    <import_uploader>Inchoo_PHP7_Model_Import_Uploader</import_uploader>
                    ...
```

Here is the part of the `Mage_ImportExport` module which creates an instance of the uploader class without using the `Mage::getModel` factory: 
(Class `Mage_ImportExport_Model_Import_Entity_Product` in Line 1622)
```
    /**
     * Returns an object for upload a media files
     */
    protected function _getUploader()
    {
        if (is_null($this->_fileUploader)) {
            $this->_fileUploader    = new Mage_ImportExport_Model_Import_Uploader();

            $this->_fileUploader->init();

            $tmpDir     = Mage::getConfig()->getOptions()->getMediaDir() . '/import';
            $destDir    = Mage::getConfig()->getOptions()->getMediaDir() . '/catalog/product';
            if (!is_writable($destDir)) {
                @mkdir($destDir, 0777, true);
            }
            if (!$this->_fileUploader->setTmpDir($tmpDir)) {
                Mage::throwException("File directory '{$tmpDir}' is not readable.");
            }
            if (!$this->_fileUploader->setDestDir($destDir)) {
                Mage::throwException("File directory '{$destDir}' is not writable.");
            }
        }
        return $this->_fileUploader;
    }
```

I decided to use the `Mage::getModel` factory. The model rewrite works now.

The main problem was that the import function of the `Mage_ImportExport` module didn't import any image because an exception was thrown in line 135 of `Mage_ImportExport_Model_Import_Uploader`: 

![image](https://cloud.githubusercontent.com/assets/8912877/17622038/2cdb9950-6098-11e6-80de-86731ad62eea.png)

I got following messages in the `system.log`: 
```
Notice: Array to string conversion  in [...]/app/code/core/Mage/ImportExport/Model/Import/Uploader.php on line 135
Notice: Undefined property: Mage_Catalog_Helper_Image::$Array  in [...]/app/code/core/Mage/ImportExport/Model/Import/Uploader.php on line 135
```


