### PR TITLE
renaming Inchoo_PHP7_Helper_Data to Mage_Core_Helper_Inchoo_PHP7_Data…

### DIFF
--- a/app/code/local/Inchoo/PHP7/etc/config.xml
+++ b/app/code/local/Inchoo/PHP7/etc/config.xml
@@ -52,7 +52,7 @@
         <helpers>
             <core>
                 <rewrite>
-                    <data>Inchoo_PHP7_Helper_Data</data>
+                    <data>Mage_Core_Helper_Inchoo_PHP7_Data</data>
                 </rewrite>
             </core>
         </helpers>

--- a/app/code/local/Mage/Core/Helper/Inchoo/PHP7/Data.php
+++ b/app/code/local/Mage/Core/Helper/Inchoo/PHP7/Data.php
@@ -1,6 +1,6 @@
 <?php
 
-class Inchoo_PHP7_Helper_Data extends Mage_Core_Helper_Data {
+class Mage_Core_Helper_Inchoo_PHP7_Data extends Mage_Core_Helper_Data {
 
     /**
      * Decodes the given $encodedValue string which is

--- a/modman
+++ b/modman
@@ -1,10 +1,11 @@
 # app/code
-app/code/local/Inchoo/PHP7                          app/code/local/Inchoo/PHP7
+app/code/local/Inchoo/PHP7                              app/code/local/Inchoo/PHP7
 
 # app/etc
-app/etc/modules/Inchoo_PHP7.xml                     app/etc/modules/Inchoo_PHP7.xml
+app/etc/modules/Inchoo_PHP7.xml                         app/etc/modules/Inchoo_PHP7.xml
 
 # mage/core
-app/code/local/Mage/Connect/Packager.php            app/code/local/Mage/Connect/Packager.php
-app/code/local/Mage/Core/Model/File/Uploader.php    app/code/local/Mage/Core/Model/File/Uploader.php
-app/code/local/Mage/Core/Model/Resource/Session.php app/code/local/Mage/Core/Model/Resource/Session.php
+app/code/local/Mage/Connect/Packager.php                app/code/local/Mage/Connect/Packager.php
+app/code/local/Mage/Core/Model/File/Uploader.php        app/code/local/Mage/Core/Model/File/Uploader.php
+app/code/local/Mage/Core/Model/Resource/Session.php     app/code/local/Mage/Core/Model/Resource/Session.php
+app/code/local/Mage/Core/Helper/Inchoo/PHP7/Data.php    app/code/local/Mage/Core/Helper/Inchoo/PHP7/Data.php


### PR DESCRIPTION
… to fix csv translations with Mage_Core:: prefix

We had an issue with an translation.csv in one module with this example: "Mage_Core::Please enter a valid phone number. For example (123) 456-7890 or 123-456-7890.","Bitte eine gültige Telefonnummer mit Vorwahl eingeben." This commit renames the Inchoo_PHP7_Helper, so Mage_Core prefix in translation file will continue working.