### PR TITLE
php7.1 patch

### DIFF
--- a/app/code/local/Inchoo/PHP7/Model/Core/Layout.php
+++ b/app/code/local/Inchoo/PHP7/Model/Core/Layout.php
@@ -1,0 +1,31 @@
+<?php
+
+/**
+ * Layout model
+ *
+ * @category   Local
+ * @package    Inchoo_PHP7_Core
+ * @author     Pieter Paßmann (ppassmannpriv)
+ */
+class Inchoo_PHP7_Model_Core_Layout extends Mage_Core_Model_Layout
+{
+
+    /**
+     * Get all blocks marked for output
+     *
+     * Added fix for PHP 7.1
+     *
+     * @return string
+     */
+    public function getOutput()
+    {
+        $out = '';
+        if (!empty($this->_output)) {
+            foreach ($this->_output as $callback) {
+                $out .= $this->getBlock($callback[0])->{$callback[1]}();
+            }
+        }
+
+        return $out;
+    }
+}

--- a/app/code/local/Inchoo/PHP7/etc/config.xml
+++ b/app/code/local/Inchoo/PHP7/etc/config.xml
@@ -14,5 +14,12 @@
                 </rewrite>
             </core>
         </helpers>
+        <models>
+            <core>
+                <rewrite>
+                    <layout>Inchoo_PHP7_Model_Core_Layout</layout>
+                </rewrite>
+            </core>
+        </models>
     </global>
 </config>


### PR DESCRIPTION
I wanted to use Magento 1.9.2.4 on PHP 7.1 and wasn't able to with the latest version of Inchoo_PHP7 so I made changes to the config.xml to overwrite Mage_Core_Model_Layout and change getOutput(), so it can run on PHP7.1